### PR TITLE
Add missing annotations in tests fixtures

### DIFF
--- a/tests/fixtures/configs.py
+++ b/tests/fixtures/configs.py
@@ -16,7 +16,7 @@ from ebm.core.config import (
 
 
 @pytest.fixture
-def default_rbm_config():
+def default_rbm_config() -> RBMConfig:
     """Provide a default RBM configuration for testing."""
     return RBMConfig(
         visible_units=784,
@@ -31,7 +31,7 @@ def default_rbm_config():
 
 
 @pytest.fixture
-def small_rbm_config():
+def small_rbm_config() -> RBMConfig:
     """Provide a small RBM configuration for fast testing."""
     return RBMConfig(
         visible_units=20,
@@ -47,7 +47,7 @@ def small_rbm_config():
 
 
 @pytest.fixture
-def gaussian_rbm_config():
+def gaussian_rbm_config() -> GaussianRBMConfig:
     """Provide a Gaussian RBM configuration."""
     return GaussianRBMConfig(
         visible_units=100,
@@ -63,7 +63,7 @@ def gaussian_rbm_config():
 
 
 @pytest.fixture
-def training_config(tmp_path: Path):
+def training_config(tmp_path: Path) -> TrainingConfig:
     """Provide a training configuration."""
     return TrainingConfig(
         epochs=10,
@@ -87,7 +87,7 @@ def training_config(tmp_path: Path):
 
 
 @pytest.fixture
-def sampler_configs():
+def sampler_configs() -> dict[str, object]:
     """Provide various sampler configurations."""
     return {
         "gibbs": GibbsConfig(num_steps=10, block_gibbs=True),
@@ -100,7 +100,7 @@ def sampler_configs():
 
 
 @pytest.fixture
-def config_variations():
+def config_variations() -> list[dict[str, object]]:
     """Provide various configuration variations for parametrized testing."""
     return [
         # Different initialization strategies
@@ -121,7 +121,7 @@ def config_variations():
 
 
 @pytest.fixture
-def invalid_configs():
+def invalid_configs() -> list[dict[str, object]]:
     """Provide invalid configurations for error testing."""
     return [
         # Invalid dimensions

--- a/tests/fixtures/datasets.py
+++ b/tests/fixtures/datasets.py
@@ -1,5 +1,7 @@
 """Dataset fixtures for testing."""
 
+from collections.abc import Callable
+
 import numpy as np
 import pytest
 import torch
@@ -7,7 +9,7 @@ from torch.utils.data import DataLoader, TensorDataset
 
 
 @pytest.fixture
-def synthetic_binary_data():
+def synthetic_binary_data() -> dict[str, object]:
     """Provide synthetic binary data for testing."""
     n_samples = 1000
     n_features = 100
@@ -34,7 +36,7 @@ def synthetic_binary_data():
 
 
 @pytest.fixture
-def synthetic_continuous_data():
+def synthetic_continuous_data() -> dict[str, object]:
     """Provide synthetic continuous data for testing."""
     n_samples = 1000
     n_features = 50
@@ -73,7 +75,7 @@ def synthetic_continuous_data():
 
 
 @pytest.fixture
-def mini_mnist_dataset():
+def mini_mnist_dataset() -> dict[str, object]:
     """Provide a mini MNIST-like dataset for testing."""
     n_samples = 500
     image_size = 28
@@ -130,7 +132,7 @@ def mini_mnist_dataset():
 
 
 @pytest.fixture
-def make_structured_data():
+def make_structured_data() -> Callable[[int, int, str, float], TensorDataset]:
     """Create structured test data."""
 
     def _make_structured_data(
@@ -138,7 +140,7 @@ def make_structured_data():
         n_features: int = 50,
         structure_type: str = "bars",
         noise_level: float = 0.1,
-    ):
+    ) -> TensorDataset:
         """Create structured data with specific patterns."""
         torch.manual_seed(42)
 
@@ -195,15 +197,15 @@ def make_structured_data():
 
 
 @pytest.fixture
-def make_data_loader():
+def make_data_loader() -> Callable[[TensorDataset, int, bool, int], DataLoader]:
     """Create simple data loaders."""
 
     def _make_data_loader(
-        dataset,
+        dataset: TensorDataset,
         batch_size: int = 32,
         shuffle: bool = True,
         num_workers: int = 0,
-    ):
+    ) -> DataLoader:
         """Create a data loader from a dataset."""
         return DataLoader(
             dataset,
@@ -217,10 +219,10 @@ def make_data_loader():
 
 
 @pytest.fixture
-def data_statistics():
+def data_statistics() -> Callable[[torch.Tensor], dict[str, object]]:
     """Fixture providing data statistics computation."""
 
-    def _compute_statistics(data: torch.Tensor):
+    def _compute_statistics(data: torch.Tensor) -> dict[str, object]:
         """Compute comprehensive statistics for data."""
         return {
             "mean": data.mean().item(),

--- a/tests/fixtures/models.py
+++ b/tests/fixtures/models.py
@@ -1,11 +1,13 @@
 """Model fixtures for testing."""
 
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
 import torch
 
 from ebm.core.config import GaussianRBMConfig, RBMConfig
+from ebm.models.base import EnergyBasedModel
 from ebm.models.rbm import (
     BernoulliRBM,
     CenteredBernoulliRBM,
@@ -14,7 +16,7 @@ from ebm.models.rbm import (
 
 
 @pytest.fixture
-def simple_bernoulli_rbm(small_rbm_config):
+def simple_bernoulli_rbm(small_rbm_config: RBMConfig) -> BernoulliRBM:
     """Provide a simple Bernoulli RBM for testing."""
     model = BernoulliRBM(small_rbm_config)
 
@@ -29,7 +31,7 @@ def simple_bernoulli_rbm(small_rbm_config):
 
 
 @pytest.fixture
-def small_gaussian_rbm():
+def small_gaussian_rbm() -> GaussianBernoulliRBM:
     """Provide a small Gaussian RBM for testing."""
     config = GaussianRBMConfig(
         visible_units=20,
@@ -44,7 +46,10 @@ def small_gaussian_rbm():
 
 
 @pytest.fixture
-def pretrained_rbm(simple_bernoulli_rbm, synthetic_binary_data):
+def pretrained_rbm(
+    simple_bernoulli_rbm: BernoulliRBM,
+    synthetic_binary_data: dict[str, object],
+) -> BernoulliRBM:
     """Provide a pre-trained RBM for testing inference."""
     model = simple_bernoulli_rbm
     data = synthetic_binary_data["data"]
@@ -72,15 +77,15 @@ def pretrained_rbm(simple_bernoulli_rbm, synthetic_binary_data):
 
 
 @pytest.fixture
-def make_test_rbm():
+def make_test_rbm() -> Callable[[int, int, str], EnergyBasedModel]:
     """Create test RBMs with various configurations."""
 
     def _make_test_rbm(
         visible_units: int = 100,
         hidden_units: int = 50,
         model_type: str = "bernoulli",
-        **kwargs,
-    ):
+        **kwargs: object,
+    ) -> EnergyBasedModel:
         """Create a test RBM with specified configuration."""
         base_config = {
             "visible_units": visible_units,
@@ -106,7 +111,9 @@ def make_test_rbm():
 
 
 @pytest.fixture
-def model_comparison_suite(make_test_rbm):
+def model_comparison_suite(
+    make_test_rbm: Callable[[int, int, str], EnergyBasedModel],
+) -> dict[str, EnergyBasedModel]:
     """Provide a suite of models for comparison testing."""
     return {
         "small_bernoulli": make_test_rbm(20, 10, "bernoulli"),
@@ -118,10 +125,16 @@ def model_comparison_suite(make_test_rbm):
 
 
 @pytest.fixture
-def save_and_load_model(tmp_path: Path):
+def save_and_load_model(
+    tmp_path: Path,
+) -> Callable[
+    [EnergyBasedModel, str], tuple[EnergyBasedModel, dict[str, torch.Tensor]]
+]:
     """Fixture for testing model save/load functionality."""
 
-    def _save_and_load(model, filename: str = "test_model.pt"):
+    def _save_and_load(
+        model: EnergyBasedModel, filename: str = "test_model.pt"
+    ) -> tuple[EnergyBasedModel, dict[str, torch.Tensor]]:
         """Save a model and load it back."""
         save_path = tmp_path / filename
 
@@ -143,10 +156,10 @@ def save_and_load_model(tmp_path: Path):
 
 
 @pytest.fixture
-def model_parameter_stats():
+def model_parameter_stats() -> Callable[[EnergyBasedModel], dict[str, object]]:
     """Fixture for computing model parameter statistics."""
 
-    def _compute_stats(model):
+    def _compute_stats(model: EnergyBasedModel) -> dict[str, object]:
         """Compute statistics for model parameters."""
         stats = {}
 


### PR DESCRIPTION
## Summary
- add return type hints to test fixtures
- type arguments for dataset and mock helpers
- clean up imports and format via ruff

## Testing
- `ruff check .` *(fails: ANN201 etc. in other files)*
- `ruff format .`


------
https://chatgpt.com/codex/tasks/task_e_683f0dc8be2c832bb62cdcbac136c6e2