### PR TITLE
Fix missing type annotations

### DIFF
--- a/examples/rbm-mnist.py
+++ b/examples/rbm-mnist.py
@@ -16,6 +16,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 import ebm
+from ebm.core.config import ModelConfig
+from ebm.models.base import EnergyBasedModel
 from ebm import (
     AISEstimator,
     BernoulliRBM,
@@ -38,7 +40,7 @@ from ebm import (
 )
 
 
-def parse_args():
+def parse_args() -> argparse.Namespace:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description="Train RBM on MNIST")
 
@@ -130,7 +132,9 @@ def parse_args():
     return parser.parse_args()
 
 
-def create_model(args):
+def create_model(
+    args: argparse.Namespace,
+) -> tuple[EnergyBasedModel, ModelConfig]:
     """Create RBM model based on arguments."""
     # Model configuration
     if args.model == "gaussian":
@@ -160,7 +164,9 @@ def create_model(args):
     return model, config
 
 
-def create_sampler(args, model):
+def create_sampler(
+    args: argparse.Namespace, model: EnergyBasedModel
+) -> ebm.GradientEstimator:
     """Create gradient estimator based on arguments."""
     if args.sampler == "cd":
         sampler = ContrastiveDivergence(k=args.k)

--- a/tests/unit/core/test_device.py
+++ b/tests/unit/core/test_device.py
@@ -350,14 +350,14 @@ class TestDecorators:
         # Mock clear_cache
         original_clear_cache = DeviceManager.clear_cache
 
-        def mock_clear_cache(self) -> None:
+        def mock_clear_cache(self: DeviceManager) -> None:
             clear_cache_called.append(True)
             original_clear_cache(self)
 
         with patch.object(DeviceManager, "clear_cache", mock_clear_cache):
 
             @memory_efficient
-            def dummy_function():
+            def dummy_function() -> torch.Tensor:
                 return torch.randn(100, 100)
 
             result = dummy_function()

--- a/tests/unit/core/test_logging.py
+++ b/tests/unit/core/test_logging.py
@@ -56,7 +56,7 @@ class TestLogConfig:
         assert config.file == Path("logs/test.log")
 
     @patch("structlog.configure")
-    def test_setup(self, mock_configure) -> None:
+    def test_setup(self, mock_configure: MagicMock) -> None:
         """Test logger setup."""
         config = LogConfig(
             level="INFO", console=True, structured=False, metrics=True
@@ -310,31 +310,31 @@ class TestConvenienceFunctions:
     """Test module-level convenience functions."""
 
     @patch("ebm.core.logging.logger")
-    def test_debug(self, mock_logger) -> None:
+    def test_debug(self, mock_logger: MagicMock) -> None:
         """Test debug convenience function."""
         debug("Debug message", value=123)
         mock_logger.debug.assert_called_once_with("Debug message", value=123)
 
     @patch("ebm.core.logging.logger")
-    def test_info(self, mock_logger) -> None:
+    def test_info(self, mock_logger: MagicMock) -> None:
         """Test info convenience function."""
         info("Info message", status="ok")
         mock_logger.info.assert_called_once_with("Info message", status="ok")
 
     @patch("ebm.core.logging.logger")
-    def test_warning(self, mock_logger) -> None:
+    def test_warning(self, mock_logger: MagicMock) -> None:
         """Test warning convenience function."""
         warning("Warning message")
         mock_logger.warning.assert_called_once_with("Warning message")
 
     @patch("ebm.core.logging.logger")
-    def test_error(self, mock_logger) -> None:
+    def test_error(self, mock_logger: MagicMock) -> None:
         """Test error convenience function."""
         error("Error message", code=500)
         mock_logger.error.assert_called_once_with("Error message", code=500)
 
     @patch("ebm.core.logging.logger")
-    def test_metrics(self, mock_logger) -> None:
+    def test_metrics(self, mock_logger: MagicMock) -> None:
         """Test metrics convenience function."""
         metrics("Training metrics", loss=0.123, accuracy=0.95)
         mock_logger.info.assert_called_once_with(
@@ -346,7 +346,7 @@ class TestSetupLogging:
     """Test setup_logging function."""
 
     @patch("ebm.core.logging.LogConfig")
-    def test_setup_logging_defaults(self, mock_config_class) -> None:
+    def test_setup_logging_defaults(self, mock_config_class: MagicMock) -> None:
         """Test setup with default parameters."""
         mock_config = MagicMock()
         mock_config.setup.return_value = MagicMock()
@@ -365,7 +365,7 @@ class TestSetupLogging:
         mock_config.setup.assert_called_once()
 
     @patch("ebm.core.logging.LogConfig")
-    def test_setup_logging_custom(self, mock_config_class) -> None:
+    def test_setup_logging_custom(self, mock_config_class: MagicMock) -> None:
         """Test setup with custom parameters."""
         mock_config = MagicMock()
         mock_config.setup.return_value = MagicMock()
@@ -393,7 +393,7 @@ class TestSetupLogging:
 class TestIntegration:
     """Integration tests for logging system."""
 
-    def test_full_logging_flow(self, tmp_path) -> None:
+    def test_full_logging_flow(self, tmp_path: Path) -> None:
         """Test complete logging workflow."""
         log_file = tmp_path / "test.log"
 
@@ -418,7 +418,7 @@ class TestIntegration:
         assert "Warning message" in content
         assert "Error message" in content
 
-    def test_structured_logging(self, tmp_path) -> None:
+    def test_structured_logging(self, tmp_path: Path) -> None:
         """Test structured JSON logging."""
         log_file = tmp_path / "structured.log"
 

--- a/tests/unit/models/rbm/test_bernoulli.py
+++ b/tests/unit/models/rbm/test_bernoulli.py
@@ -2,6 +2,8 @@
 
 import torch
 from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+from collections.abc import Callable
 
 from ebm.core.config import RBMConfig
 from ebm.models.rbm.bernoulli import (
@@ -14,7 +16,7 @@ from ebm.models.rbm.bernoulli import (
 class TestBernoulliRBM:
     """Test standard Bernoulli RBM."""
 
-    def test_initialization(self, small_rbm_config) -> None:
+    def test_initialization(self, small_rbm_config: RBMConfig) -> None:
         """Test Bernoulli RBM initialization."""
         rbm = BernoulliRBM(small_rbm_config)
 
@@ -132,7 +134,7 @@ class TestBernoulliRBM:
 class TestCenteredBernoulliRBM:
     """Test centered Bernoulli RBM."""
 
-    def test_initialization(self, small_rbm_config) -> None:
+    def test_initialization(self, small_rbm_config: RBMConfig) -> None:
         """Test centered RBM initialization."""
         rbm = CenteredBernoulliRBM(small_rbm_config)
 
@@ -262,7 +264,9 @@ class TestCenteredBernoulliRBM:
         assert torch.allclose(rbm.h_offset, expected_h)
 
     def test_init_from_data_centered(
-        self, synthetic_binary_data, make_data_loader
+        self,
+        synthetic_binary_data: dict[str, object],
+        make_data_loader: Callable[[TensorDataset, int, bool, int], DataLoader],
     ) -> None:
         """Test data initialization for centered RBM."""
         config = RBMConfig(visible_units=100, hidden_units=50)
@@ -377,7 +381,7 @@ class TestSparseBernoulliRBM:
 class TestBernoulliRBMProperties:
     """Test mathematical properties of Bernoulli RBMs."""
 
-    def test_energy_gradient(self, simple_bernoulli_rbm) -> None:
+    def test_energy_gradient(self, simple_bernoulli_rbm: BernoulliRBM) -> None:
         """Test that energy gradient matches implementation."""
         rbm = simple_bernoulli_rbm
 
@@ -438,7 +442,9 @@ class TestBernoulliRBMProperties:
 
         assert abs(total_prob - 1.0) < 1e-5
 
-    def test_conditional_independence(self, simple_bernoulli_rbm) -> None:
+    def test_conditional_independence(
+        self, simple_bernoulli_rbm: BernoulliRBM
+    ) -> None:
         """Test conditional independence property of RBMs."""
         rbm = simple_bernoulli_rbm
 

--- a/tests/unit/models/rbm/test_gaussian.py
+++ b/tests/unit/models/rbm/test_gaussian.py
@@ -2,6 +2,8 @@
 
 import torch
 from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+from collections.abc import Callable
 
 from ebm.core.config import GaussianRBMConfig
 from ebm.models.rbm.gaussian import GaussianBernoulliRBM, WhitenedGaussianRBM
@@ -10,7 +12,9 @@ from ebm.models.rbm.gaussian import GaussianBernoulliRBM, WhitenedGaussianRBM
 class TestGaussianBernoulliRBM:
     """Test Gaussian-Bernoulli RBM."""
 
-    def test_initialization(self, gaussian_rbm_config) -> None:
+    def test_initialization(
+        self, gaussian_rbm_config: GaussianRBMConfig
+    ) -> None:
         """Test Gaussian RBM initialization."""
         rbm = GaussianBernoulliRBM(gaussian_rbm_config)
 
@@ -296,7 +300,9 @@ class TestWhitenedGaussianRBM:
         assert rbm.whitening_std is None
 
     def test_fit_whitening(
-        self, synthetic_continuous_data, make_data_loader
+        self,
+        synthetic_continuous_data: dict[str, object],
+        make_data_loader: Callable[[TensorDataset, int, bool, int], DataLoader],
     ) -> None:
         """Test fitting whitening transformation."""
         config = GaussianRBMConfig(

--- a/tests/unit/models/test_base.py
+++ b/tests/unit/models/test_base.py
@@ -21,7 +21,13 @@ class ConcreteEnergyModel(EnergyBasedModel):
         self.weight = nn.Parameter(torch.randn(10, 10))
         self.bias = nn.Parameter(torch.zeros(10))
 
-    def energy(self, x: Tensor, *, beta=None, return_parts=False):
+    def energy(
+        self,
+        x: Tensor,
+        *,
+        beta: float | None = None,
+        return_parts: bool = False,
+    ) -> Tensor | dict[str, Tensor]:
         """Compute the model energy for a batch."""
         x.shape[0]
         # Simple quadratic energy
@@ -38,13 +44,13 @@ class ConcreteEnergyModel(EnergyBasedModel):
             }
         return energy
 
-    def free_energy(self, v: Tensor, *, beta=None):
+    def free_energy(self, v: Tensor, *, beta: float | None = None) -> Tensor:
         """Return free energy, delegating to ``energy``."""
         # For testing, just use energy
         return self.energy(v, beta=beta)
 
     @classmethod
-    def get_config_class(cls):
+    def get_config_class(cls) -> type[ModelConfig]:
         """Return the config class used for this model."""
         return ModelConfig
 
@@ -57,7 +63,13 @@ class ConcreteLatentModel(LatentVariableModel):
         self.vbias = nn.Parameter(torch.zeros(10))
         self.hbias = nn.Parameter(torch.zeros(20))
 
-    def energy(self, x: Tensor, *, beta=None, return_parts=False):
+    def energy(
+        self,
+        x: Tensor,
+        *,
+        beta: float | None = None,
+        return_parts: bool = False,
+    ) -> Tensor | dict[str, Tensor]:
         """Compute energy for visible and hidden units."""
         # Split into visible and hidden
         v = x[..., :10]
@@ -81,7 +93,7 @@ class ConcreteLatentModel(LatentVariableModel):
             }
         return energy
 
-    def free_energy(self, v: Tensor, *, beta=None):
+    def free_energy(self, v: Tensor, *, beta: float | None = None) -> Tensor:
         """Compute free energy of visible units."""
         pre_h = v @ self.W.T + self.hbias
         if beta is not None:
@@ -95,7 +107,13 @@ class ConcreteLatentModel(LatentVariableModel):
         ).sum(-1)
         return v_term + h_term
 
-    def sample_hidden(self, visible: Tensor, *, beta=None, return_prob=False):
+    def sample_hidden(
+        self,
+        visible: Tensor,
+        *,
+        beta: float | None = None,
+        return_prob: bool = False,
+    ) -> Tensor | tuple[Tensor, Tensor]:
         """Sample hidden units from visibles."""
         pre_h = visible @ self.W.T + self.hbias
         if beta is not None:
@@ -107,7 +125,13 @@ class ConcreteLatentModel(LatentVariableModel):
             return sample_h, prob_h
         return sample_h
 
-    def sample_visible(self, hidden: Tensor, *, beta=None, return_prob=False):
+    def sample_visible(
+        self,
+        hidden: Tensor,
+        *,
+        beta: float | None = None,
+        return_prob: bool = False,
+    ) -> Tensor | tuple[Tensor, Tensor]:
         """Sample visible units from hiddens."""
         pre_v = hidden @ self.W + self.vbias
         if beta is not None:
@@ -120,7 +144,7 @@ class ConcreteLatentModel(LatentVariableModel):
         return sample_v
 
     @classmethod
-    def get_config_class(cls):
+    def get_config_class(cls) -> type[ModelConfig]:
         """Return the configuration class for the model."""
         return ModelConfig
 
@@ -478,7 +502,7 @@ class TestAISInterpolator:
             def base_log_partition(self) -> float:
                 return 0.0
 
-            def base_energy(self, x):
+            def base_energy(self, x: Tensor) -> Tensor:
                 # Simple base energy (uniform distribution)
                 return torch.zeros(x.shape[0])
 
@@ -518,7 +542,13 @@ class TestEdgeCases:
             def _build_model(self) -> None:
                 pass
 
-            def energy(self, x, *, beta=None, return_parts=False) -> None:
+            def energy(
+                self,
+                x: Tensor,
+                *,
+                beta: float | None = None,
+                return_parts: bool = False,
+            ) -> None:
                 """Unimplemented energy function."""
                 pass
 


### PR DESCRIPTION
## Summary
- add explicit return and argument annotations across example and tests

## Testing
- `ruff check examples/rbm-mnist.py tests/unit/core/test_device.py tests/unit/core/test_logging.py tests/unit/inference/test_partition.py tests/unit/models/rbm/test_bernoulli.py tests/unit/models/rbm/test_gaussian.py tests/unit/models/rbm/test_rbm_base.py tests/unit/models/test_base.py --select ANN`
- `pytest -k "nothing" -q` *(fails: ConfigError duplicate validator function)*

------
https://chatgpt.com/codex/tasks/task_e_683f13e385f4832bab617d51f39f3413