### PR TITLE
Fix ruff lint errors in tests

### DIFF
--- a/tests/unit/inference/test_partition.py
+++ b/tests/unit/inference/test_partition.py
@@ -1,6 +1,7 @@
 """Unit tests for partition function estimation."""
 
 import math
+from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
 
 import numpy as np
@@ -15,6 +16,9 @@ from ebm.inference.partition import (
     SimpleIS,
 )
 from ebm.models.base import EnergyBasedModel, LatentVariableModel
+
+if TYPE_CHECKING:  # pragma: no cover - type-checking imports
+    from ebm.models.rbm.base import RBMAISAdapter
 
 
 class MockRBM(LatentVariableModel):
@@ -88,7 +92,7 @@ class MockRBM(LatentVariableModel):
             v = self.sample_visible(h)
         return v
 
-    def ais_adapter(self) -> "RBMAISAdapter":
+    def ais_adapter(self) -> RBMAISAdapter:
         """Create AIS adapter."""
         from ebm.models.rbm.base import RBMAISAdapter
 

--- a/tests/unit/sampling/test_base.py
+++ b/tests/unit/sampling/test_base.py
@@ -189,12 +189,12 @@ class TestGibbsSampler:
         model = Mock(spec=LatentVariableModel)
         counter = 0
 
-        def mock_sample_hidden(v, **kwargs):
+        def mock_sample_hidden(v: torch.Tensor, **kwargs: Any) -> torch.Tensor:
             nonlocal counter
             counter += 1
             return torch.rand_like(v) + counter * 0.01
 
-        def mock_sample_visible(h, **kwargs):
+        def mock_sample_visible(h: torch.Tensor, **kwargs: Any) -> torch.Tensor:
             return torch.rand_like(h) + counter * 0.01
 
         model.sample_hidden.side_effect = mock_sample_hidden

--- a/tests/unit/sampling/test_deterministic.py
+++ b/tests/unit/sampling/test_deterministic.py
@@ -18,14 +18,20 @@ from ebm.sampling.mcmc import (
 class MockLatentModel(LatentVariableModel):
     """Mock model for testing."""
 
-    def __init__(self, n_visible=10, n_hidden=5) -> None:
+    def __init__(self, n_visible: int = 10, n_hidden: int = 5) -> None:
         self.num_visible = n_visible
         self.num_hidden = n_hidden
         self.W = nn.Parameter(torch.randn(n_hidden, n_visible) * 0.01)
         self.vbias = nn.Parameter(torch.zeros(n_visible))
         self.hbias = nn.Parameter(torch.zeros(n_hidden))
 
-    def sample_hidden(self, visible, *, beta=None, return_prob=False):
+    def sample_hidden(
+        self,
+        visible: torch.Tensor,
+        *,
+        beta: torch.Tensor | None = None,
+        return_prob: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         """Sample hidden layer from visible units."""
         pre_h = visible @ self.W.T + self.hbias
         if beta is not None:
@@ -40,7 +46,13 @@ class MockLatentModel(LatentVariableModel):
             return sample_h, prob_h
         return sample_h
 
-    def sample_visible(self, hidden, *, beta=None, return_prob=False):
+    def sample_visible(
+        self,
+        hidden: torch.Tensor,
+        *,
+        beta: torch.Tensor | None = None,
+        return_prob: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         """Sample visible layer from hidden units."""
         pre_v = hidden @ self.W + self.vbias
         if beta is not None:
@@ -55,7 +67,9 @@ class MockLatentModel(LatentVariableModel):
             return sample_v, prob_v
         return sample_v
 
-    def free_energy(self, v, *, beta=None):
+    def free_energy(
+        self, v: torch.Tensor, *, beta: torch.Tensor | None = None
+    ) -> torch.Tensor:
         """Compute free energy of visible units."""
         pre_h = v @ self.W.T + self.hbias
         if beta is not None:
@@ -70,7 +84,13 @@ class MockLatentModel(LatentVariableModel):
         h_term = torch.nn.functional.softplus(pre_h).sum(dim=-1)
         return -v_term - h_term
 
-    def energy(self, x, *, beta=None, return_parts=False):
+    def energy(
+        self,
+        x: torch.Tensor,
+        *,
+        beta: torch.Tensor | None = None,
+        return_parts: bool = False,
+    ) -> torch.Tensor | dict[str, torch.Tensor]:
         """Compute energy for joint configuration."""
         v = x[..., : self.num_visible]
         h = x[..., self.num_visible :]
@@ -94,12 +114,12 @@ class MockLatentModel(LatentVariableModel):
         return energy
 
     @property
-    def device(self):
+    def device(self) -> torch.device:
         """Return the tensor device."""
         return self.W.device
 
     @property
-    def dtype(self):
+    def dtype(self) -> torch.dtype:
         """Return the tensor dtype."""
         return self.W.dtype
 
@@ -192,7 +212,7 @@ class TestParallelTempering:
             pt.chains[0, 1] = torch.ones(5) * 1.0  # Chain 0, temp 1
 
         # Mock energy calculations to force acceptance
-        def mock_free_energy(v):
+        def mock_free_energy(v: torch.Tensor) -> torch.Tensor:
             # Make energy of state 1.0 lower than state 0.0
             return torch.where(
                 v.mean() > 0.5, torch.tensor(-10.0), torch.tensor(0.0)

--- a/tests/unit/sampling/test_gradient.py
+++ b/tests/unit/sampling/test_gradient.py
@@ -20,14 +20,20 @@ from ebm.utils.tensor import batch_outer_product
 class MockLatentModel(LatentVariableModel):
     """Mock latent variable model for testing."""
 
-    def __init__(self, n_visible=20, n_hidden=10) -> None:
+    def __init__(self, n_visible: int = 20, n_hidden: int = 10) -> None:
         self.num_visible = n_visible
         self.num_hidden = n_hidden
         self.W = nn.Parameter(torch.randn(n_hidden, n_visible) * 0.01)
         self.vbias = nn.Parameter(torch.zeros(n_visible))
         self.hbias = nn.Parameter(torch.zeros(n_hidden))
 
-    def sample_hidden(self, visible, *, beta=None, return_prob=False):
+    def sample_hidden(
+        self,
+        visible: torch.Tensor,
+        *,
+        beta: torch.Tensor | None = None,
+        return_prob: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         """Sample hidden units from visible layer."""
         pre_h = visible @ self.W.T + self.hbias
         if beta is not None:
@@ -39,7 +45,13 @@ class MockLatentModel(LatentVariableModel):
             return sample_h, prob_h
         return sample_h
 
-    def sample_visible(self, hidden, *, beta=None, return_prob=False):
+    def sample_visible(
+        self,
+        hidden: torch.Tensor,
+        *,
+        beta: torch.Tensor | None = None,
+        return_prob: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         """Sample visible units from hidden layer."""
         pre_v = hidden @ self.W + self.vbias
         if beta is not None:
@@ -51,7 +63,9 @@ class MockLatentModel(LatentVariableModel):
             return sample_v, prob_v
         return sample_v
 
-    def free_energy(self, v, *, beta=None):
+    def free_energy(
+        self, v: torch.Tensor, *, beta: torch.Tensor | None = None
+    ) -> torch.Tensor:
         """Compute free energy of visible units."""
         pre_h = v @ self.W.T + self.hbias
         if beta is not None:
@@ -63,21 +77,27 @@ class MockLatentModel(LatentVariableModel):
         return -v_term - h_term
 
     @property
-    def device(self):
+    def device(self) -> torch.device:
         """Return device of model parameters."""
         return self.W.device
 
     @property
-    def dtype(self):
+    def dtype(self) -> torch.dtype:
         """Return dtype of model parameters."""
         return self.W.dtype
 
-    def energy(self, x, *, beta=None, return_parts=False):
+    def energy(
+        self,
+        x: torch.Tensor,
+        *,
+        beta: torch.Tensor | None = None,
+        return_parts: bool = False,
+    ) -> torch.Tensor:
         """Return constant energy (not used in CD)."""
         # Not used in CD
         return torch.zeros(x.shape[0])
 
-    def named_parameters(self):
+    def named_parameters(self) -> list[tuple[str, nn.Parameter]]:
         """Return model parameters as name-parameter pairs."""
         return [("W", self.W), ("vbias", self.vbias), ("hbias", self.hbias)]
 

--- a/tests/unit/sampling/test_mcmc.py
+++ b/tests/unit/sampling/test_mcmc.py
@@ -18,14 +18,20 @@ from ebm.sampling.mcmc import (
 class MockLatentModel(LatentVariableModel):
     """Mock model for testing."""
 
-    def __init__(self, n_visible=10, n_hidden=5) -> None:
+    def __init__(self, n_visible: int = 10, n_hidden: int = 5) -> None:
         self.num_visible = n_visible
         self.num_hidden = n_hidden
         self.W = nn.Parameter(torch.randn(n_hidden, n_visible) * 0.01)
         self.vbias = nn.Parameter(torch.zeros(n_visible))
         self.hbias = nn.Parameter(torch.zeros(n_hidden))
 
-    def sample_hidden(self, visible, *, beta=None, return_prob=False):
+    def sample_hidden(
+        self,
+        visible: torch.Tensor,
+        *,
+        beta: torch.Tensor | None = None,
+        return_prob: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         """Sample hidden units given visible layer."""
         pre_h = visible @ self.W.T + self.hbias
         if beta is not None:
@@ -40,7 +46,13 @@ class MockLatentModel(LatentVariableModel):
             return sample_h, prob_h
         return sample_h
 
-    def sample_visible(self, hidden, *, beta=None, return_prob=False):
+    def sample_visible(
+        self,
+        hidden: torch.Tensor,
+        *,
+        beta: torch.Tensor | None = None,
+        return_prob: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         """Sample visible units given hidden layer."""
         pre_v = hidden @ self.W + self.vbias
         if beta is not None:
@@ -55,7 +67,9 @@ class MockLatentModel(LatentVariableModel):
             return sample_v, prob_v
         return sample_v
 
-    def free_energy(self, v, *, beta=None):
+    def free_energy(
+        self, v: torch.Tensor, *, beta: torch.Tensor | None = None
+    ) -> torch.Tensor:
         """Compute free energy of visible samples."""
         pre_h = v @ self.W.T + self.hbias
         if beta is not None:
@@ -70,7 +84,13 @@ class MockLatentModel(LatentVariableModel):
         h_term = torch.nn.functional.softplus(pre_h).sum(dim=-1)
         return -v_term - h_term
 
-    def energy(self, x, *, beta=None, return_parts=False):
+    def energy(
+        self,
+        x: torch.Tensor,
+        *,
+        beta: torch.Tensor | None = None,
+        return_parts: bool = False,
+    ) -> torch.Tensor | dict[str, torch.Tensor]:
         """Compute joint energy of visible and hidden layers."""
         v = x[..., : self.num_visible]
         h = x[..., self.num_visible :]
@@ -94,12 +114,12 @@ class MockLatentModel(LatentVariableModel):
         return energy
 
     @property
-    def device(self):
+    def device(self) -> torch.device:
         """Return tensor device."""
         return self.W.device
 
     @property
-    def dtype(self):
+    def dtype(self) -> torch.dtype:
         """Return tensor dtype."""
         return self.W.dtype
 
@@ -192,7 +212,7 @@ class TestParallelTempering:
             pt.chains[0, 1] = torch.ones(5) * 1.0  # Chain 0, temp 1
 
         # Mock energy calculations to force acceptance
-        def mock_free_energy(v):
+        def mock_free_energy(v: torch.Tensor) -> torch.Tensor:
             # Make energy of state 1.0 lower than state 0.0
             return torch.where(
                 v.mean() > 0.5, torch.tensor(-10.0), torch.tensor(0.0)

--- a/tests/unit/utils/test_visualization.py
+++ b/tests/unit/utils/test_visualization.py
@@ -32,7 +32,9 @@ class TestSetupStyle:
     @patch("ebm.utils.visualization.HAS_SEABORN", True)
     @patch("seaborn.set_style")
     @patch("seaborn.set_context")
-    def test_with_seaborn(self, mock_set_context, mock_set_style) -> None:
+    def test_with_seaborn(
+        self, mock_set_context: MagicMock, mock_set_style: MagicMock
+    ) -> None:
         """Test style setup with seaborn available."""
         setup_style("whitegrid")
 
@@ -41,7 +43,7 @@ class TestSetupStyle:
 
     @patch("ebm.utils.visualization.HAS_SEABORN", False)
     @patch("matplotlib.pyplot.style.use")
-    def test_without_seaborn(self, mock_style_use) -> None:
+    def test_without_seaborn(self, mock_style_use: MagicMock) -> None:
         """Test style setup without seaborn."""
         # Mock available styles
         with patch(
@@ -164,7 +166,10 @@ class TestVisualizeFilters:
     @patch("matplotlib.pyplot.tight_layout")
     @patch("matplotlib.pyplot.colorbar")
     def test_square_filters(
-        self, mock_colorbar, mock_tight_layout, mock_savefig
+        self,
+        mock_colorbar: MagicMock,
+        mock_tight_layout: MagicMock,
+        mock_savefig: MagicMock,
     ) -> None:
         """Test visualizing square filters."""
         # Create filter weights (25 filters of size 16)
@@ -182,7 +187,7 @@ class TestVisualizeFilters:
         plt.close(fig)
 
     @patch("matplotlib.pyplot.savefig")
-    def test_non_square_filters(self, mock_savefig) -> None:
+    def test_non_square_filters(self, mock_savefig: MagicMock) -> None:
         """Test visualizing non-square filters."""
         # 10 filters of size 30 (not square)
         weights = torch.randn(10, 30)
@@ -194,7 +199,7 @@ class TestVisualizeFilters:
 
         plt.close(fig)
 
-    def test_save_filters(self, tmp_path) -> None:
+    def test_save_filters(self, tmp_path: Path) -> None:
         """Test saving filter visualization."""
         weights = torch.randn(16, 25)
         save_path = tmp_path / "filters.png"
@@ -280,7 +285,7 @@ class TestVisualizeSamples:
 
         plt.close(fig)
 
-    def test_save_samples(self, tmp_path) -> None:
+    def test_save_samples(self, tmp_path: Path) -> None:
         """Test saving sample visualization."""
         samples = torch.randn(16, 64)
         save_path = tmp_path / "samples.png"
@@ -385,7 +390,7 @@ class TestPlotTrainingCurves:
 
         plt.close(fig)
 
-    def test_save_curves(self, tmp_path) -> None:
+    def test_save_curves(self, tmp_path: Path) -> None:
         """Test saving training curves."""
         history = {"train": [{"loss": 1.0}]}
         save_path = tmp_path / "curves.png"
@@ -501,7 +506,7 @@ class TestCreateAnimation:
     """Test animation creation."""
 
     @patch("matplotlib.animation.FuncAnimation")
-    def test_basic_animation(self, mock_animation) -> None:
+    def test_basic_animation(self, mock_animation: MagicMock) -> None:
         """Test creating basic animation."""
         # Create sequence of frames
         frames = [torch.randn(32, 32) for _ in range(10)]
@@ -517,7 +522,7 @@ class TestCreateAnimation:
         plt.close("all")
 
     @patch("matplotlib.animation.FuncAnimation")
-    def test_save_animation(self, mock_animation_class) -> None:
+    def test_save_animation(self, mock_animation_class: MagicMock) -> None:
         """Test saving animation."""
         frames = [torch.randn(16, 16) for _ in range(5)]
 


### PR DESCRIPTION
## Summary
- add TYPE_CHECKING import for RBMAISAdapter
- annotate test helper functions with tensor types
- add missing return/argument annotations across test modules
- mark MagicMock arguments in visualization tests

## Testing
- `ruff check tests/unit/inference/test_partition.py tests/unit/sampling/test_base.py tests/unit/sampling/test_deterministic.py tests/unit/sampling/test_gradient.py tests/unit/sampling/test_mcmc.py tests/unit/training/test_metrics.py tests/unit/utils/test_visualization.py`
- `pytest tests/unit/inference/test_partition.py tests/unit/sampling/test_base.py tests/unit/sampling/test_deterministic.py tests/unit/sampling/test_gradient.py tests/unit/sampling/test_mcmc.py tests/unit/training/test_metrics.py tests/unit/utils/test_visualization.py -q` *(fails: Coverage failure: total of 1 is less than fail-under=80)*

------
https://chatgpt.com/codex/tasks/task_e_683f177687fc832b8954f1aa6bf7bb21