### PR TITLE
Fix type hints in tests

### DIFF
--- a/tests/unit/utils/test_data.py
+++ b/tests/unit/utils/test_data.py
@@ -349,7 +349,7 @@ class TestMNISTDatasets:
     """Test MNIST dataset functions."""
 
     @patch("torchvision.datasets.MNIST")
-    def test_get_mnist_datasets(self, mock_mnist) -> None:
+    def test_get_mnist_datasets(self, mock_mnist: Mock) -> None:
         """Test MNIST dataset loading."""
         # Mock dataset
         mock_data = torch.randn(100, 1, 28, 28)
@@ -380,7 +380,7 @@ class TestMNISTDatasets:
         assert transform is not None
 
     @patch("torchvision.datasets.FashionMNIST")
-    def test_get_fashion_mnist_datasets(self, mock_fashion) -> None:
+    def test_get_fashion_mnist_datasets(self, mock_fashion: Mock) -> None:
         """Test Fashion-MNIST dataset loading."""
         # Mock dataset
         mock_dataset = MagicMock()
@@ -548,7 +548,7 @@ class TestEdgeCases:
         add_noise = AddNoise(noise_type="gaussian", noise_level=0.1)
 
         # Manual chaining
-        def chained_transform(x):
+        def chained_transform(x: torch.Tensor) -> torch.Tensor:
             x = binarize(x)
             return add_noise(x)
 

--- a/tests/unit/utils/test_initialization.py
+++ b/tests/unit/utils/test_initialization.py
@@ -54,7 +54,7 @@ class TestInitializer:
         assert torch.all(tensor == 0)
 
         # Callable method
-        def custom_init(t) -> None:
+        def custom_init(t: torch.Tensor) -> None:
             t.fill_(42.0)
 
         init = Initializer(custom_init)


### PR DESCRIPTION
## Summary
- add missing type annotations in test files
- update fixtures and helper functions accordingly

## Testing
- `ruff check tests/unit/training/test_callbacks.py tests/unit/training/test_trainer.py tests/unit/utils/test_data.py tests/unit/utils/test_initialization.py`
- `pytest -q` *(fails: pydantic ConfigError)*

------
https://chatgpt.com/codex/tasks/task_e_683f1b8884b8832b976d6cbc98ce7ba7