### PR TITLE
Fix RBM base tests

### DIFF
--- a/ebm/core/config.py
+++ b/ebm/core/config.py
@@ -338,7 +338,7 @@ class RBMConfig(ModelConfig):
     weight_init: str = Field(
         "xavier_normal", description="Weight initialization method"
     )
-    bias_init: str | float = Field(0.0, description="Bias initialization")
+    bias_init: float | str = Field(0.0, description="Bias initialization")
 
     # Architecture variants
     use_bias: bool = Field(True, description="Use bias terms")
@@ -381,6 +381,16 @@ class RBMConfig(ModelConfig):
             raise ValueError(
                 f"Unknown init method: {v}. Must be one of {valid_methods}"
             )
+        return v
+
+    @validator("bias_init", pre=True)
+    def parse_bias_init(cls, v: str | float) -> str | float:  # noqa: N805
+        """Parse numeric bias initialization values correctly."""
+        if isinstance(v, str):
+            try:
+                return float(v)
+            except ValueError:
+                return v
         return v
 
 

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -8,6 +8,7 @@ from .configs import (
     training_config,
 )
 from .datasets import (
+    make_data_loader,
     make_structured_data,
     mini_mnist_dataset,
     synthetic_binary_data,
@@ -27,24 +28,21 @@ from .models import (
 )
 
 __all__ = [
-    # From configs
     "default_rbm_config",
     "gaussian_rbm_config",
+    "make_data_loader",
     "make_structured_data",
     "make_test_rbm",
     "mini_mnist_dataset",
     "mock_callback",
-    # From mocks
     "mock_data_loader",
     "mock_gradient_estimator",
     "mock_sampler",
     "pretrained_rbm",
     "sampler_configs",
-    # From models
     "simple_bernoulli_rbm",
     "small_gaussian_rbm",
     "small_rbm_config",
-    # From datasets
     "synthetic_binary_data",
     "synthetic_continuous_data",
     "training_config",

--- a/tests/unit/models/rbm/test_rbm_base.py
+++ b/tests/unit/models/rbm/test_rbm_base.py
@@ -389,7 +389,7 @@ class TestRBMAISAdapter:
 
         # Manually compute interpolated energy
         interaction = torch.einsum(
-            "...h,...v->...",
+            "...h,...h->...",
             h,
             torch.nn.functional.linear(v, simple_bernoulli_rbm.W),
         )


### PR DESCRIPTION
## Summary
- expose `make_data_loader` fixture
- handle numeric `bias_init` values correctly
- fix AIS adapter test typo

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest tests/unit/models/rbm/test_rbm_base.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683f9e19da2c832bb1a133ea761a4189