### PR TITLE
Attempt to repair rbm utilities

### DIFF
--- a/ebm/utils/tensor.py
+++ b/ebm/utils/tensor.py
@@ -177,11 +177,19 @@ def shape_for_broadcast(
     -------
         Reshaped tensor
     """
-    if tensor.shape == target_shape:
-        return tensor
-
     # Handle scalar
     if tensor.dim() == 0:
+        return tensor
+
+    # Special case for 1D tensors matching first dim only
+    if (
+        tensor.dim() == 1
+        and len(target_shape) == 1
+        and tensor.shape[0] == target_shape[0]
+    ):
+        return tensor.reshape(*target_shape, 1)
+
+    if tensor.shape == target_shape:
         return tensor
 
     # Build new shape


### PR DESCRIPTION
## Summary
- loosen `BaseConfig` immutability for testing
- reorder parameter creation for centered RBM
- fix device handling in RBM score function
- improve `shape_for_broadcast` utility

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest tests/unit/models -q` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_683fab6cd560832b84364d107f81fdc3