### PR TITLE
Address device defaults and broadcasting

### DIFF
--- a/ebm/core/config.py
+++ b/ebm/core/config.py
@@ -117,8 +117,8 @@ class ModelConfig(BaseConfig):
         None, description="Random seed for reproducibility"
     )
 
-    @validator("device")
-    def validate_device(cls, v: str | None) -> str | None:  # noqa: N805
+    @validator("device", pre=True, always=True)
+    def validate_device(cls, v: str | None) -> str:  # noqa: N805
         """Validate and normalize device string."""
         if v is None:
             return "cpu"

--- a/ebm/models/rbm/base.py
+++ b/ebm/models/rbm/base.py
@@ -153,11 +153,13 @@ class RBMBase(LatentVariableModel):
                 "hidden_bias": -h_bias_term,
             }
             if beta is not None:
-                beta = torch.as_tensor(
+                beta_t = torch.as_tensor(
                     beta, device=self.device, dtype=self.dtype
                 )
-                beta = shape_for_broadcast(beta, visible.shape[:-1])
-                parts = {k: beta * v for k, v in parts.items()}
+                beta_view = shape_for_broadcast(
+                    beta_t, visible.shape[:-1], dim=0
+                )
+                parts = {k: beta_view * v for k, v in parts.items()}
             parts["total"] = sum(parts.values())
             return parts
 
@@ -165,9 +167,9 @@ class RBMBase(LatentVariableModel):
         energy = -(interaction + v_bias_term + h_bias_term)
 
         if beta is not None:
-            beta = torch.as_tensor(beta, device=self.device, dtype=self.dtype)
-            beta = shape_for_broadcast(beta, energy.shape)
-            energy = beta * energy
+            beta_t = torch.as_tensor(beta, device=self.device, dtype=self.dtype)
+            beta_view = shape_for_broadcast(beta_t, energy.shape, dim=0)
+            energy = beta_view * energy
 
         return energy
 
@@ -191,10 +193,11 @@ class RBMBase(LatentVariableModel):
 
         # Apply temperature scaling if needed
         if beta is not None:
-            beta = torch.as_tensor(beta, device=self.device, dtype=self.dtype)
-            beta = shape_for_broadcast(beta, pre_h.shape[:-1])
-            pre_h = beta * pre_h
-            v_bias_term = beta * torch.einsum("...v,v->...", v, self.vbias)
+            beta_t = torch.as_tensor(beta, device=self.device, dtype=self.dtype)
+            pre_beta = shape_for_broadcast(beta_t, pre_h.shape)
+            pre_h = pre_beta * pre_h
+            bias_beta = shape_for_broadcast(beta_t, v.shape[:-1], dim=0)
+            v_bias_term = bias_beta * torch.einsum("...v,v->...", v, self.vbias)
         else:
             v_bias_term = torch.einsum("...v,v->...", v, self.vbias)
 

--- a/ebm/utils/tensor.py
+++ b/ebm/utils/tensor.py
@@ -181,13 +181,13 @@ def shape_for_broadcast(
     if tensor.dim() == 0:
         return tensor
 
-    # Special case for 1D tensors matching first dim only
+    # Special case for 1D tensors matching first dimension
     if (
         tensor.dim() == 1
         and len(target_shape) == 1
         and tensor.shape[0] == target_shape[0]
     ):
-        return tensor.reshape(*target_shape, 1)
+        return tensor.reshape(*target_shape)
 
     if tensor.shape == target_shape:
         return tensor


### PR DESCRIPTION
## Summary
- ensure device validation always defaults to CPU
- fix broadcasting helper for 1D tensors
- handle beta broadcasting explicitly in RBMs

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest tests/unit/models -q` *(fails: 10 failed, 75 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_683ff2b739e4832bba9cd61ced477c23