### PR TITLE
chore: add development setup script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# Development Guidelines for the EBM Project
+
+This document defines standards for automated agents contributing to this
+repository.
+
+## Commit Message Standards
+- Use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
+- Start the subject with a **type** (`feat`, `fix`, `chore`, `docs`, `test`, etc.).
+- Keep the subject line under 72 characters.
+- Provide a body when the change is not trivial.
+
+## Commit Sequencing
+- Group related changes into atomic commits.
+- Run linting and tests before every commit.
+
+## Pull Request Standards
+- Title should use Conventional Commits style.
+- Describe the purpose of the PR, testing instructions, and any context.
+
+## Code Housekeeping
+- Keep dependencies up to date.
+- Remove dead code when encountered.
+- Track performance or security issues via TODO comments referencing issues.
+
+## Architecture and Design
+- Document significant decisions in `docs/adr/` using the
+  [ADR](https://adr.github.io/) format.
+- Keep modules focused; avoid cross‑package imports where possible.
+
+## Pre-commit Checks
+- `ruff --fix` for linting and formatting.
+- `mypy` for type checking.
+- `pytest` for the test suite.
+- `bandit -r ebm` for security checks.
+
+## Version Management
+- Follow [Semantic Versioning](https://semver.org/).
+- Bump `pyproject.toml` version on release commits.
+
+## CHANGELOG Maintenance
+- Add an entry under `Unreleased` for every user facing change.
+- Use the categories: Added, Changed, Deprecated, Removed, Fixed, Security.
+
+## Testing Standards
+- Organize tests under `tests/` by type (unit, integration, etc.).
+- Aim for high coverage of critical utilities.
+
+## Documentation Standards
+- Update `README.md` when public APIs change.
+- Keep docstrings in NumPy style.
+
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # ebm
+
 Energy-based models
+
+## Development setup
+
+Run `./setup-dev.sh` on a machine with internet access to install all
+requirements and cache example datasets. After the script completes, activate
+the virtual environment with:
+
+```bash
+source .venv/bin/activate
+```
+
+Run tests using:
+
+```bash
+poetry run pytest
+```
+

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -euo pipefail
+
+# setup-dev.sh - Prepare local development environment for the EBM project
+# This script installs all Python dependencies using Poetry and pre-downloads
+# example datasets so that development can continue without internet access.
+# It is idempotent and safe to run multiple times.
+
+PROJECT_ROOT="$(cd "$(dirname "$0")" && pwd)"
+VENV_DIR="$PROJECT_ROOT/.venv"
+POETRY_VERSION="1.8.2"
+
+# Ensure required system packages are installed
+sudo apt-get update
+sudo apt-get install -y python3-venv git curl build-essential
+
+# Create Python virtual environment if it doesn't exist
+if [ ! -d "$VENV_DIR" ]; then
+    python3 -m venv "$VENV_DIR"
+fi
+source "$VENV_DIR/bin/activate"
+
+# Upgrade pip and install Poetry if needed
+pip install --upgrade pip
+if ! command -v poetry >/dev/null 2>&1; then
+    pip install "poetry==${POETRY_VERSION}"
+fi
+
+# Configure Poetry to use the in-project virtualenv
+poetry config virtualenvs.create false --local || true
+
+# Install project dependencies including development extras
+poetry install --with dev,viz,extras
+
+# Pre-download MNIST and Fashion-MNIST datasets for offline use
+python - <<'PY'
+from torchvision import datasets
+from pathlib import Path
+root = Path('data')
+root.mkdir(exist_ok=True)
+datasets.MNIST(root, train=True, download=True)
+datasets.MNIST(root, train=False, download=True)
+datasets.FashionMNIST(root, train=True, download=True)
+datasets.FashionMNIST(root, train=False, download=True)
+print('Datasets cached in', root.resolve())
+PY
+
+# Basic verification
+poetry run python -c "import ebm, torch; print('EBM', ebm.__version__, 'Torch', torch.__version__)"
+
+cat <<'MSG'
+
+Development environment setup complete.
+Activate the virtual environment using:
+  source .venv/bin/activate
+
+Run tests with:
+  poetry run pytest
+
+MSG
+


### PR DESCRIPTION
## Summary
- add setup-dev.sh for offline development
- outline contributor standards in AGENTS.md
- document environment setup in README

## Testing
- `bash -n setup-dev.sh`
- `./setup-dev.sh` *(runs install and dataset download)*
- `poetry run python -c "import ebm, torch; print('EBM', ebm.__version__, 'Torch', torch.__version__)"`

------
https://chatgpt.com/codex/tasks/task_e_68494721533c832bb971fa31a51485dd